### PR TITLE
Feat :  Add images modal: layout and styling aligned with Figma

### DIFF
--- a/src/components/dialogs/ImageNameHintIcon.vue
+++ b/src/components/dialogs/ImageNameHintIcon.vue
@@ -1,0 +1,34 @@
+<template>
+  <q-icon
+    name="info_outline"
+    size="16px"
+    class="image-name-hint-icon cursor-pointer"
+    color="grey-5"
+  >
+    <q-tooltip
+      anchor="top middle"
+      self="bottom middle"
+      :offset="[0, 8]"
+      max-width="320px"
+    >
+      <div class="text-body2 text-weight-bold q-mb-xs">
+        {{ $t('imageNameHint.title') }}
+      </div>
+      <div class="text-caption">
+        {{ $t('imageNameHint.body') }}
+      </div>
+    </q-tooltip>
+  </q-icon>
+</template>
+
+<script>
+export default {
+  name: 'ImageNameHintIcon'
+}
+</script>
+
+<style scoped>
+.image-name-hint-icon {
+  vertical-align: middle;
+}
+</style>

--- a/src/components/dialogs/TakePhotoDialog.vue
+++ b/src/components/dialogs/TakePhotoDialog.vue
@@ -1,0 +1,407 @@
+<template>
+  <q-dialog
+    :value="value"
+    @input="$emit('input', $event)"
+    @show="onDialogShow"
+    @hide="onDialogHide"
+  >
+    <q-card class="take-photo-card bg-grey-10 text-white">
+      <q-btn
+        icon="close"
+        flat
+        round
+        dense
+        class="take-photo-close"
+        color="grey-5"
+        @click="close"
+      />
+
+      <q-card-section class="q-pt-lg q-pb-sm">
+        <div class="take-photo-stage q-mx-auto">
+          <video
+            v-show="step === 'camera'"
+            ref="video"
+            class="take-photo-video"
+            playsinline
+            muted
+            autoplay
+          />
+          <div
+            v-show="step === 'crop'"
+            class="take-photo-crop-shell"
+          >
+            <canvas
+              ref="canvas"
+              class="take-photo-canvas"
+            />
+          </div>
+        </div>
+
+        <div
+          v-if="step === 'camera'"
+          class="row justify-center q-mt-md"
+        >
+          <q-btn
+            unelevated
+            no-caps
+            color="light-blue-3"
+            text-color="grey-10"
+            icon="camera_alt"
+            :label="$t('takePhoto.capture')"
+            @click="capture"
+          />
+        </div>
+
+        <div
+          v-if="step === 'crop'"
+          class="row justify-center q-mt-sm"
+        >
+          <q-btn
+            flat
+            no-caps
+            color="light-blue-3"
+            :label="$t('takePhoto.retake')"
+            @click="retake"
+          />
+        </div>
+      </q-card-section>
+
+      <q-card-section
+        v-if="step === 'crop'"
+        class="q-pt-none"
+      >
+        <div class="row q-col-gutter-sm items-end take-photo-form-row">
+          <div class="col-12 col-sm-4">
+            <div class="row items-center no-wrap q-mb-xs">
+              <span class="text-caption text-grey-5">{{ $t('takePhoto.nameLabel') }}</span>
+              <image-name-hint-icon class="q-ml-xs" />
+            </div>
+            <q-input
+              v-model="imageName"
+              outlined
+              dense
+              dark
+              color="grey-3"
+              :placeholder="$t('takePhoto.nameLabel')"
+              class="take-photo-input"
+              @keyup.enter="save"
+            />
+          </div>
+          <div class="col-12 col-sm-5">
+            <div class="row items-center q-mb-xs">
+              <span class="text-caption text-grey-5">{{ $t('takePhoto.categoryLabel') }}</span>
+            </div>
+            <q-select
+              v-model="selectedCategories"
+              outlined
+              dense
+              dark
+              multiple
+              use-chips
+              use-input
+              new-value-mode="add-unique"
+              input-debounce="0"
+              :options="categoryOptions"
+              popup-content-class="take-photo-cat-popup"
+              class="take-photo-select"
+              @new-value="onNewCategoryValue"
+            >
+              <template #selected-item="scope">
+                <q-chip
+                  dense
+                  square
+                  removable
+                  :color="chipColor(scope.opt)"
+                  text-color="white"
+                  class="q-ma-xs"
+                  @remove="scope.removeAtIndex(scope.index)"
+                >
+                  {{ scope.opt }}
+                </q-chip>
+              </template>
+              <template #option="scope">
+                <q-item
+                  v-bind="scope.itemProps"
+                  v-on="scope.itemEvents"
+                >
+                  <q-item-section>
+                    <q-chip
+                      dense
+                      square
+                      :color="chipColor(scope.opt)"
+                      text-color="white"
+                    >
+                      {{ scope.opt }}
+                    </q-chip>
+                  </q-item-section>
+                </q-item>
+              </template>
+            </q-select>
+          </div>
+          <div class="col-12 col-sm-3 flex flex-center">
+            <q-btn
+              unelevated
+              no-caps
+              color="grey-9"
+              class="full-width take-photo-save"
+              :label="$t('takePhoto.save')"
+              :loading="saving"
+              @click="save"
+            />
+          </div>
+        </div>
+      </q-card-section>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script>
+/* eslint-disable max-lines */
+import Cropper from 'cropperjs'
+import 'cropperjs/dist/cropper.css'
+
+import ImageNameHintIcon from '~/components/dialogs/ImageNameHintIcon.vue'
+
+export default {
+  name: 'TakePhotoDialog',
+  components: {
+    ImageNameHintIcon
+  },
+  props: {
+    value: {
+      type: Boolean,
+      default: false
+    },
+    categoryOptions: {
+      type: Array,
+      default: () => []
+    },
+    chipColor: {
+      type: Function,
+      required: true
+    }
+  },
+  data () {
+    return {
+      step: 'camera',
+      imageName: '',
+      selectedCategories: [],
+      cropper: null,
+      stream: null,
+      saving: false
+    }
+  },
+  watch: {
+    value (open) {
+      if (!open) {
+        this.resetState()
+      }
+    }
+  },
+  methods: {
+    close () {
+      this.$emit('input', false)
+    },
+
+    resetState () {
+      this.step = 'camera'
+      this.imageName = ''
+      this.selectedCategories = []
+      this.saving = false
+      this.destroyCropper()
+    },
+
+    destroyCropper () {
+      if (this.cropper) {
+        this.cropper.destroy()
+        this.cropper = null
+      }
+    },
+
+    stopStream () {
+      if (this.stream) {
+        this.stream.getTracks().forEach((t) => t.stop())
+        this.stream = null
+      }
+      if (this.$refs.video) {
+        this.$refs.video.srcObject = null
+      }
+    },
+
+    onDialogShow () {
+      this.startCamera()
+    },
+
+    onDialogHide () {
+      this.stopStream()
+      this.destroyCropper()
+    },
+
+    startCamera () {
+      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        this.$q.notify({
+          color: 'negative',
+          message: this.$t('takePhoto.noCamera'),
+          position: 'top-right'
+        })
+
+        return
+      }
+      const constraints = { video: { facingMode: 'user', width: { ideal: 720 }, height: { ideal: 720 } } }
+      navigator.mediaDevices.getUserMedia(constraints)
+        .then((stream) => {
+          this.stream = stream
+          this.$refs.video.srcObject = stream
+        })
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error(err)
+          const msg = err && err.message ? err.message : String(err)
+          this.$q.notify({
+            color: 'negative',
+            message: msg,
+            position: 'top-right'
+          })
+        })
+    },
+
+    capture () {
+      const { video, canvas } = this.$refs
+      if (!video || !canvas || !video.videoWidth) {
+        this.$q.notify({
+          color: 'warning',
+          message: this.$t('takePhoto.waitCamera'),
+          position: 'top-right'
+        })
+
+        return
+      }
+      canvas.width = video.videoWidth
+      canvas.height = video.videoHeight
+      const ctx = canvas.getContext('2d')
+      ctx.drawImage(video, 0, 0)
+      this.stopStream()
+      this.step = 'crop'
+      this.$nextTick(() => {
+        this.destroyCropper()
+        this.cropper = new Cropper(canvas, {
+          aspectRatio: 1,
+          viewMode: 1,
+          dragMode: 'move',
+          guides: true,
+          background: false,
+          autoCropArea: 0.85,
+          responsive: true,
+          restore: false
+        })
+      })
+    },
+
+    retake () {
+      this.destroyCropper()
+      this.step = 'camera'
+      this.startCamera()
+    },
+
+    onNewCategoryValue (val, done) {
+      const name = (val || '').trim()
+      if (!name) {
+        done('')
+
+        return
+      }
+      this.$emit('add-category', name)
+      done(name, 'add-unique')
+    },
+
+    save () {
+      if (!this.cropper || this.saving) {
+        return
+      }
+      const name = (this.imageName || '').trim() || this.$t('takePhoto.defaultName')
+      this.saving = true
+      const out = this.cropper.getCroppedCanvas({ width: 512, height: 512, imageSmoothingQuality: 'high' })
+      out.toBlob((blob) => {
+        if (!blob) {
+          this.saving = false
+
+          return
+        }
+        const safe = name.replace(/[^\w\s\-àâäéèêëïîôùûüç]/gi, '').trim() || 'photo'
+        const file = new File([blob], `${safe}.png`, { type: 'image/png' })
+        this.$store.dispatch('assetsManager/uploadPersonalPhoto', {
+          file,
+          name,
+          categories: this.selectedCategories
+        })
+          .then(() => {
+            this.$emit('saved')
+            this.close()
+          })
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.error(err)
+            const msg = err && err.message ? err.message : String(err)
+            this.$q.notify({
+              color: 'negative',
+              message: msg,
+              position: 'top-right'
+            })
+          })
+          .finally(() => {
+            this.saving = false
+          })
+      }, 'image/png', 0.92)
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+.take-photo-card
+  position relative
+  width 100%
+  max-width 520px
+  border-radius 12px
+
+.take-photo-close
+  position absolute
+  top 8px
+  right 8px
+  z-index 2
+
+.take-photo-stage
+  max-width 360px
+
+.take-photo-video
+  display block
+  width 100%
+  aspect-ratio 1
+  object-fit cover
+  border 3px solid #42a5f5
+  border-radius 4px
+  background #1a1a1a
+
+.take-photo-crop-shell
+  width 100%
+  max-height 320px
+  border 3px solid #42a5f5
+  border-radius 4px
+  overflow hidden
+  background #1a1a1a
+
+.take-photo-canvas
+  display block
+  max-width 100%
+
+.take-photo-form-row
+  margin-top 4px
+
+.take-photo-save
+  min-height 40px
+</style>
+
+<style lang="stylus">
+.take-photo-cat-popup
+  min-width 260px
+</style>

--- a/src/components/dialogs/UploadPhotoDialog.vue
+++ b/src/components/dialogs/UploadPhotoDialog.vue
@@ -1,0 +1,252 @@
+<template>
+  <q-dialog
+    :value="value"
+    @input="$emit('input', $event)"
+    @hide="onHide"
+  >
+    <q-card
+      v-if="file"
+      class="upload-photo-card bg-grey-10 text-white"
+    >
+      <q-btn
+        icon="close"
+        flat
+        round
+        dense
+        class="upload-photo-close"
+        color="grey-5"
+        @click="close"
+      />
+
+      <q-card-section class="q-pt-lg">
+        <div class="text-subtitle2 text-weight-medium q-mb-md text-center">
+          {{ $t('uploadPhoto.heading') }}
+        </div>
+        <div
+          v-if="previewUrl"
+          class="upload-photo-preview q-mx-auto"
+        >
+          <q-img
+            :src="previewUrl"
+            ratio="1"
+            contain
+            class="upload-photo-preview__img bg-grey-9"
+            spinner-color="primary"
+          />
+        </div>
+
+        <div class="row q-col-gutter-sm items-end q-mt-md">
+          <div class="col-12 col-sm-4">
+            <div class="row items-center no-wrap q-mb-xs">
+              <span class="text-caption text-grey-5">{{ $t('takePhoto.nameLabel') }}</span>
+              <image-name-hint-icon class="q-ml-xs" />
+            </div>
+            <q-input
+              v-model="imageName"
+              outlined
+              dense
+              dark
+              color="grey-3"
+              :placeholder="$t('takePhoto.nameLabel')"
+              @keyup.enter="save"
+            />
+          </div>
+          <div class="col-12 col-sm-5">
+            <div class="row items-center q-mb-xs">
+              <span class="text-caption text-grey-5">{{ $t('takePhoto.categoryLabel') }}</span>
+            </div>
+            <q-select
+              v-model="selectedCategories"
+              outlined
+              dense
+              dark
+              multiple
+              use-chips
+              use-input
+              new-value-mode="add-unique"
+              input-debounce="0"
+              :options="categoryOptions"
+              popup-content-class="take-photo-cat-popup"
+              class="upload-photo-select"
+              @new-value="onNewCategoryValue"
+            >
+              <template #selected-item="scope">
+                <q-chip
+                  dense
+                  square
+                  removable
+                  :color="chipColor(scope.opt)"
+                  text-color="white"
+                  class="q-ma-xs"
+                  @remove="scope.removeAtIndex(scope.index)"
+                >
+                  {{ scope.opt }}
+                </q-chip>
+              </template>
+              <template #option="scope">
+                <q-item
+                  v-bind="scope.itemProps"
+                  v-on="scope.itemEvents"
+                >
+                  <q-item-section>
+                    <q-chip
+                      dense
+                      square
+                      :color="chipColor(scope.opt)"
+                      text-color="white"
+                    >
+                      {{ scope.opt }}
+                    </q-chip>
+                  </q-item-section>
+                </q-item>
+              </template>
+            </q-select>
+          </div>
+          <div class="col-12 col-sm-3 flex flex-center">
+            <q-btn
+              unelevated
+              no-caps
+              color="grey-9"
+              class="full-width"
+              :label="$t('takePhoto.save')"
+              :loading="saving"
+              @click="save"
+            />
+          </div>
+        </div>
+      </q-card-section>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script>
+import ImageNameHintIcon from '~/components/dialogs/ImageNameHintIcon.vue'
+
+const stripImageExtension = function (name) {
+  return (name || '').replace(/\.(jpe?g|png|gif|bmp)$/i, '').trim()
+}
+
+export default {
+  name: 'UploadPhotoDialog',
+  components: {
+    ImageNameHintIcon
+  },
+  props: {
+    value: {
+      type: Boolean,
+      default: false
+    },
+    file: {
+      type: File,
+      default: null
+    },
+    categoryOptions: {
+      type: Array,
+      default: () => []
+    },
+    chipColor: {
+      type: Function,
+      required: true
+    }
+  },
+  data () {
+    return {
+      imageName: '',
+      selectedCategories: [],
+      saving: false,
+      previewUrl: ''
+    }
+  },
+  watch: {
+    file: {
+      handler (f) {
+        this.revokePreview()
+        if (f) {
+          this.imageName = stripImageExtension(f.name)
+          this.selectedCategories = []
+          this.previewUrl = URL.createObjectURL(f)
+        } else {
+          this.imageName = ''
+          this.previewUrl = ''
+        }
+      },
+      immediate: true
+    }
+  },
+  beforeDestroy () {
+    this.revokePreview()
+  },
+  methods: {
+    onHide () {
+      this.revokePreview()
+    },
+
+    revokePreview () {
+      if (this.previewUrl && this.previewUrl.startsWith('blob:')) {
+        URL.revokeObjectURL(this.previewUrl)
+      }
+      this.previewUrl = ''
+    },
+
+    close () {
+      this.$emit('input', false)
+    },
+
+    onNewCategoryValue (val, done) {
+      const name = (val || '').trim()
+      if (!name) {
+        done('')
+
+        return
+      }
+      this.$emit('add-category', name)
+      done(name, 'add-unique')
+    },
+
+    async save () {
+      if (!this.file || this.saving) {
+        return
+      }
+      const name = (this.imageName || '').trim() || this.$t('takePhoto.defaultName')
+      this.saving = true
+      try {
+        await this.$store.dispatch('assetsManager/uploadPersonalPhoto', {
+          file: this.file,
+          name,
+          categories: this.selectedCategories
+        })
+        this.$emit('saved')
+        this.close()
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e)
+        this.$emit('failed', e)
+      } finally {
+        this.saving = false
+      }
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+.upload-photo-card
+  position relative
+  width 100%
+  max-width 520px
+  border-radius 12px
+
+.upload-photo-close
+  position absolute
+  top 8px
+  right 8px
+  z-index 2
+
+.upload-photo-preview
+  max-width 280px
+
+.upload-photo-preview__img
+  border-radius 8px
+  border 2px solid #42a5f5
+  max-height 240px
+</style>

--- a/src/i18n/fr-fr/index.js
+++ b/src/i18n/fr-fr/index.js
@@ -42,6 +42,61 @@ export default {
     retake: 'reprendre',
     imageName: 'Nom de l\'image'
   },
+  imageNameHint: {
+    title: 'Conseil pour bien nommer l’image',
+    body: 'Donner sens au nom de l’image, car cela sera utilisé par la synthèse vocale. Veuillez enlever le suffixe .png, .jpg, .bmp, .gif de votre image.'
+  },
+  takePhoto: {
+    capture: 'Prendre la photo',
+    retake: 'Reprendre la photo',
+    nameLabel: 'Nom',
+    categoryLabel: 'Catégorie',
+    save: 'Enregistrer',
+    noCamera: 'Caméra non disponible sur cet appareil.',
+    waitCamera: 'Patientez, la caméra démarre…',
+    defaultName: 'Photo',
+    successTitle: 'Prise de photo réussie',
+    successMessage: 'Veuillez trouver votre image sur l\'onglet et dans votre bibliothèque personnelle.',
+    successOk: 'Compris'
+  },
+  uploadPhoto: {
+    heading: 'Télécharger une photo',
+    successTitle: 'Téléchargement réussi',
+    successMessage: 'Veuillez trouver votre image sur l\'onglet et dans votre bibliothèque personnelle.',
+    successOk: 'Compris'
+  },
+  uploadError: {
+    title: 'Échec d’envoi de l’image',
+    lead: 'L’image n’a pas réussi à s’envoyer.',
+    bulletExtension: 'Vérifiez l’extension de votre image : seuls les formats .jpg, .jpeg et .png sont acceptés.',
+    bulletRetry: 'Veuillez télécharger une nouvelle photo ou essayez de prendre une photo avec la caméra si possible.',
+    ok: 'Compris'
+  },
+  addImagesModal: {
+    title: 'Ajouter les images',
+    libraryArasaac: 'Bibliothèque ARASAAC',
+    libraryPersonal: 'Bibliothèque personnelle',
+    switchToPersonal: 'Bibliothèque personnelle',
+    switchToArasaac: 'Bibliothèque ARASAAC',
+    takePhoto: 'Prendre une photo',
+    uploadPhoto: 'Télécharger une photo',
+    searchArasaac: 'Rechercher un pictogramme ARASAAC',
+    searchPersonal: 'Rechercher un pictogramme',
+    filter: 'Filtre :',
+    addNewCategory: 'Ajouter une nouvelle catégorie',
+    newCategoryPlaceholder: 'Nouvelle catégorie',
+    addButton: 'Ajouter',
+    pictogramCountOne: '{n} pictogramme',
+    pictogramCountOther: '{n} pictogrammes',
+    cancel: 'Annuler',
+    addToTab: 'Ajouter',
+    renameCategoryMenu: 'Renommer…',
+    deleteCategoryMenu: 'Supprimer la catégorie',
+    assignCategoryTitle: 'Ajouter une catégorie',
+    search: 'Rechercher',
+    noCategorySearchResults: 'Aucune catégorie ne correspond à la recherche.',
+    renameCategoryTitle: 'Renommer la catégorie'
+  },
   assetsManager: {
     assetNameLabel: 'Nom de l\'image',
     nameSave: 'Nom enregistré : '

--- a/src/layouts/HomeLayout.vue
+++ b/src/layouts/HomeLayout.vue
@@ -65,7 +65,10 @@
             />
           </div>
         </q-toolbar>
-        <q-toolbar class="top-tabs-nav">
+        <q-toolbar
+          v-if="showTopTabsNav"
+          class="top-tabs-nav"
+        >
           <list-item-loading v-if="$store.state.tabs.loading" />
           <div
             v-else
@@ -186,6 +189,9 @@ export default {
      */
     tabs () {
       return this.$store.getters['tabs/tabs']
+    },
+    showTopTabsNav () {
+      return this.$route.name !== 'tab-arasaac'
     },
     selectedTab () {
       return this.$route.params.slug

--- a/src/pages/ArasaacLibrary.vue
+++ b/src/pages/ArasaacLibrary.vue
@@ -1,0 +1,1254 @@
+<!-- eslint-disable max-lines -->
+<template>
+  <div class="arasaac-page">
+    <div class="arasaac-shell">
+      <div class="row items-start justify-between q-mb-md library-top-bar">
+        <div>
+          <div class="text-h4 text-weight-bold text-grey-8">
+            {{ $t('addImagesModal.title') }}
+          </div>
+          <div class="row items-center q-mt-sm">
+            <q-icon
+              :name="activeLibrary === 'arasaac' ? 'travel_explore' : 'photo_library'"
+              color="grey-7"
+              size="18px"
+              class="q-mr-sm"
+            />
+            <div class="text-h6 text-weight-bold text-grey-9">
+              {{ activeLibrary === 'arasaac' ? $t('addImagesModal.libraryArasaac') : $t('addImagesModal.libraryPersonal') }}
+            </div>
+          </div>
+        </div>
+
+        <div class="row items-center text-center library-top-actions">
+          <div
+            class="library-action library-action--clickable"
+            @click="toggleLibrary"
+          >
+            <q-icon
+              :name="activeLibrary === 'arasaac' ? 'account_box' : 'public'"
+              color="primary"
+              size="36px"
+            />
+            <div class="library-action__label">
+              {{ activeLibrary === 'arasaac' ? $t('addImagesModal.switchToPersonal') : $t('addImagesModal.switchToArasaac') }}
+            </div>
+          </div>
+          <div
+            class="library-action library-action--clickable"
+            @click="takePhotoDialogOpen = true"
+          >
+            <q-icon
+              name="add_a_photo"
+              color="primary"
+              size="36px"
+            />
+            <div class="library-action__label">
+              {{ $t('addImagesModal.takePhoto') }}
+            </div>
+          </div>
+          <input
+            ref="uploadPhotoInput"
+            type="file"
+            class="arasaac-hidden-file-input"
+            accept=".jpg,.jpeg,.png,image/jpeg,image/png"
+            @change="onUploadFileChosen"
+          >
+          <div
+            class="library-action library-action--clickable"
+            @click="onUploadPhotoClick"
+          >
+            <q-icon
+              name="upload"
+              color="primary"
+              size="36px"
+            />
+            <div class="library-action__label">
+              {{ $t('addImagesModal.uploadPhoto') }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row items-end q-col-gutter-sm q-mb-sm">
+        <div class="col-12 col-md-6">
+          <q-input
+            v-model="search"
+            outlined
+            dense
+            :placeholder="activeLibrary === 'arasaac' ? $t('addImagesModal.searchArasaac') : $t('addImagesModal.searchPersonal')"
+          >
+            <template #prepend>
+              <q-icon name="search" />
+            </template>
+          </q-input>
+        </div>
+        <div class="col-12 col-md-4">
+          <div class="row items-center q-gutter-sm">
+            <q-icon
+              name="filter_alt"
+              color="grey-7"
+            />
+            <span class="text-grey-8">{{ $t('addImagesModal.filter') }}</span>
+            <q-select
+              v-model="selectedCategoryFilters"
+              outlined
+              dense
+              behavior="menu"
+              options-dense
+              class="category-select"
+              :options="categoryOptions"
+              multiple
+              use-chips
+              use-input
+              new-value-mode="add-unique"
+              input-debounce="0"
+              popup-content-class="category-filter-popup"
+            >
+              <template #selected-item="scope">
+                <q-chip
+                  dense
+                  square
+                  :color="chipColor(scope.opt)"
+                  text-color="white"
+                  removable
+                  class="q-ma-xs"
+                  @remove="scope.removeAtIndex(scope.index)"
+                >
+                  {{ scope.opt }}
+                </q-chip>
+              </template>
+              <template #option="scope">
+                <q-item
+                  v-bind="scope.itemProps"
+                  v-on="scope.itemEvents"
+                >
+                  <q-item-section>
+                    <q-chip
+                      dense
+                      square
+                      :color="chipColor(scope.opt)"
+                      text-color="white"
+                    >
+                      {{ scope.opt }}
+                    </q-chip>
+                  </q-item-section>
+                </q-item>
+              </template>
+            </q-select>
+          </div>
+        </div>
+      </div>
+
+      <div class="q-mb-md">
+        <div class="row items-center q-col-gutter-xs">
+          <div
+            v-for="cat in categoryOptions"
+            :key="`cat-${cat}`"
+            class="col-auto"
+          >
+            <q-chip
+              dense
+              square
+              :color="chipColor(cat)"
+              text-color="white"
+              class="category-chip"
+            >
+              <span>{{ cat }}</span>
+              <q-btn
+                flat
+                dense
+                round
+                size="9px"
+                icon="edit"
+                class="q-ml-xs text-white"
+                @click.stop="openCategoryMenu(cat, $event)"
+              />
+            </q-chip>
+          </div>
+          <div class="col-auto">
+            <q-btn
+              flat
+              dense
+              icon="add_circle"
+              color="primary"
+              no-caps
+              :label="$t('addImagesModal.addNewCategory')"
+            >
+              <q-menu
+                ref="addCategoryMenu"
+                anchor="bottom left"
+                self="top left"
+                @before-show="newCategoryName = ''"
+              >
+                <div
+                  class="q-pa-sm row items-center q-gutter-sm add-category-menu__inner"
+                >
+                  <q-input
+                    v-model="newCategoryName"
+                    outlined
+                    dense
+                    autofocus
+                    class="col"
+                    :placeholder="$t('addImagesModal.newCategoryPlaceholder')"
+                    @keyup.enter="confirmAddCategory"
+                  />
+                  <q-btn
+                    flat
+                    dense
+                    color="primary"
+                    :label="$t('addImagesModal.addButton')"
+                    @click="confirmAddCategory"
+                  />
+                </div>
+              </q-menu>
+            </q-btn>
+          </div>
+        </div>
+      </div>
+
+      <div class="row items-center justify-between q-mb-md">
+        <div class="text-grey-8 text-weight-medium">
+          {{ pictogramCountLabel }}
+        </div>
+        <div class="row q-gutter-sm">
+          <q-btn
+            class="library-footer-btn"
+            outline
+            unelevated
+            dense
+            no-caps
+            color="dark"
+            :label="$t('addImagesModal.cancel')"
+            @click="goBack"
+          />
+          <q-btn
+            class="library-footer-btn"
+            unelevated
+            dense
+            no-caps
+            color="dark"
+            :label="$t('addImagesModal.addToTab')"
+            @click="onAddSelected"
+          />
+        </div>
+      </div>
+
+      <div class="row q-col-gutter-xs library-grid">
+        <div
+          v-for="(image, index) in paginatedImages"
+          :key="`img-${page}-${index}`"
+          class="col-4 col-sm-3 col-md-2"
+        >
+          <q-card
+            flat
+            class="library-card"
+          >
+            <q-img
+              :src="image.url"
+              ratio="1"
+              contain
+              class="library-card__image"
+            >
+              <div class="absolute-top row justify-between q-pa-xs library-card__actions">
+                <q-btn
+                  round
+                  dense
+                  flat
+                  icon="play_arrow"
+                  color="primary"
+                  class="library-card__action-btn"
+                  :disable="$store.getters['global/ttsEnabled'] === false"
+                  @click.stop="$store.getters['global/tts'].speak({ text: image.name })"
+                />
+                <q-checkbox
+                  v-model="selectedUrls"
+                  :val="image.url"
+                  dense
+                  color="primary"
+                  class="library-card__checkbox"
+                />
+              </div>
+
+              <div
+                v-if="isHidden(image.url)"
+                class="absolute-full image-overlay image-overlay--hidden"
+              >
+                <q-icon
+                  name="visibility_off"
+                  class="overlay-icon"
+                />
+              </div>
+              <div
+                v-else-if="isUnavailable(image.url)"
+                class="absolute-full image-overlay image-overlay--unavailable"
+              >
+                <q-icon
+                  name="close"
+                  class="overlay-icon overlay-icon--cross"
+                />
+              </div>
+            </q-img>
+            <div class="library-card__name">
+              {{ image.name }}
+            </div>
+            <div class="library-card__categories">
+              <q-chip
+                v-for="cat in image.categories || []"
+                :key="`${image.id}-${cat}`"
+                dense
+                square
+                :color="chipColor(cat)"
+                text-color="white"
+                class="image-category-chip"
+              >
+                {{ cat }}
+              </q-chip>
+              <q-btn
+                flat
+                dense
+                round
+                size="10px"
+                icon="add"
+                color="primary"
+                class="library-card__add-cat"
+                @click.stop="openImageCategoryDialog(image)"
+              />
+            </div>
+          </q-card>
+        </div>
+      </div>
+
+      <div class="row justify-center q-mt-sm q-pt-sm q-pb-md library-pagination">
+        <q-pagination
+          v-model="page"
+          :max="pageCount"
+          :max-pages="10"
+          class="library-pagination__q"
+          direction-links
+          boundary-links
+          flat
+          rounded
+          color="black"
+          text-color="black"
+          active-color="grey-4"
+          active-text-color="black"
+        />
+      </div>
+    </div>
+
+    <q-menu
+      v-model="categoryMenuOpen"
+      :target="categoryMenuTarget"
+      self="top left"
+      anchor="bottom left"
+    >
+      <q-list
+        dense
+        style="min-width: 180px"
+      >
+        <q-item
+          clickable
+          @click="startRenameCategory"
+        >
+          <q-item-section avatar>
+            <q-icon name="edit" />
+          </q-item-section>
+          <q-item-section>{{ $t('addImagesModal.renameCategoryMenu') }}</q-item-section>
+        </q-item>
+        <q-item
+          clickable
+          @click="deleteCategoryFromAll"
+        >
+          <q-item-section avatar>
+            <q-icon
+              name="delete"
+              color="negative"
+            />
+          </q-item-section>
+          <q-item-section class="text-negative">
+            {{ $t('addImagesModal.deleteCategoryMenu') }}
+          </q-item-section>
+        </q-item>
+      </q-list>
+    </q-menu>
+
+    <q-dialog
+      v-model="imageCategoryDialogOpen"
+      @hide="onImageCategoryDialogHide"
+    >
+      <q-card class="image-category-dialog-card">
+        <q-card-section class="row items-center q-pb-sm">
+          <div class="text-subtitle1 text-weight-bold text-grey-9">
+            {{ $t('addImagesModal.assignCategoryTitle') }}
+          </div>
+          <q-space />
+          <q-btn
+            v-close-popup
+            flat
+            round
+            dense
+            icon="close"
+            color="grey-7"
+          />
+        </q-card-section>
+
+        <q-separator />
+
+        <q-card-section class="q-pt-md">
+          <q-input
+            v-model="newCategoryNameForImage"
+            outlined
+            dense
+            autofocus
+            class="q-mb-md image-category-dialog__new-input"
+            :placeholder="$t('addImagesModal.newCategoryPlaceholder')"
+            @keyup.enter="submitNewCategoryFromImageDialog"
+          />
+
+          <q-input
+            v-model="imageCategorySearch"
+            outlined
+            dense
+            clearable
+            class="q-mb-md"
+            :placeholder="$t('addImagesModal.search')"
+          >
+            <template #prepend>
+              <q-icon
+                name="search"
+                color="grey-7"
+              />
+            </template>
+          </q-input>
+
+          <q-scroll-area
+            class="image-category-dialog__scroll"
+            :thumb-style="{ borderRadius: '4px', width: '6px' }"
+            :bar-style="{ borderRadius: '4px', width: '6px' }"
+          >
+            <div
+              v-if="!filteredCategoriesForImageDialog.length"
+              class="text-grey-7 text-caption q-py-sm"
+            >
+              {{ $t('addImagesModal.noCategorySearchResults') }}
+            </div>
+            <div
+              v-else
+              class="column q-gutter-sm"
+            >
+              <q-chip
+                v-for="cat in filteredCategoriesForImageDialog"
+                :key="`pick-${cat}`"
+                clickable
+                dense
+                square
+                :color="chipColor(cat)"
+                text-color="white"
+                class="image-category-dialog__chip"
+                @click="pickCategoryForImage(cat)"
+              >
+                {{ cat }}
+              </q-chip>
+            </div>
+          </q-scroll-area>
+        </q-card-section>
+
+        <q-card-actions
+          align="right"
+          class="q-px-md q-pb-md"
+        >
+          <q-btn
+            v-close-popup
+            flat
+            no-caps
+            :label="$t('generic.close')"
+            color="grey-8"
+          />
+          <q-btn
+            unelevated
+            no-caps
+            color="primary"
+            :label="$t('addImagesModal.addButton')"
+            :disable="!(newCategoryNameForImage || '').trim()"
+            @click="submitNewCategoryFromImageDialog"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+
+    <q-dialog v-model="renameCategoryDialogOpen">
+      <q-card style="min-width: 320px">
+        <q-card-section class="text-h6">
+          {{ $t('addImagesModal.renameCategoryTitle') }}
+        </q-card-section>
+        <q-card-section>
+          <q-input
+            v-model="renameCategoryName"
+            outlined
+            dense
+            autofocus
+            @keyup.enter="confirmRenameCategory"
+          />
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn
+            flat
+            :label="$t('generic.cancel')"
+            @click="renameCategoryDialogOpen = false"
+          />
+          <q-btn
+            flat
+            color="primary"
+            :label="$t('generic.validate')"
+            @click="confirmRenameCategory"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+
+    <take-photo-dialog
+      v-model="takePhotoDialogOpen"
+      :category-options="categoryOptions"
+      :chip-color="chipColor"
+      @saved="onTakePhotoSaved"
+      @add-category="onTakePhotoAddCategory"
+    />
+
+    <upload-photo-dialog
+      :value="uploadPhotoDialogOpen"
+      :file="pendingUploadFile"
+      :category-options="categoryOptions"
+      :chip-color="chipColor"
+      @input="onUploadPhotoDialogInput"
+      @saved="onUploadPhotoSaved"
+      @failed="onUploadPhotoFailed"
+      @add-category="onTakePhotoAddCategory"
+    />
+
+    <q-dialog
+      v-model="personalPhotoSuccessOpen"
+    >
+      <q-card class="take-photo-success-card">
+        <q-card-section class="column items-center q-pt-xl q-px-lg q-pb-md">
+          <q-avatar
+            color="positive"
+            text-color="white"
+            size="56px"
+            font-size="28px"
+            icon="check"
+          />
+          <div class="text-h6 text-weight-bold text-grey-9 q-mt-md text-center">
+            {{ personalPhotoSuccessTitle }}
+          </div>
+          <div class="text-body2 text-grey-7 text-center q-mt-sm">
+            {{ personalPhotoSuccessMessage }}
+          </div>
+        </q-card-section>
+        <q-card-actions
+          align="center"
+          class="q-pb-lg"
+        >
+          <q-btn
+            unelevated
+            no-caps
+            color="primary"
+            :label="personalPhotoSuccessOk"
+            @click="personalPhotoSuccessOpen = false"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+
+    <q-dialog
+      v-model="uploadErrorDialogOpen"
+    >
+      <q-card class="take-photo-success-card">
+        <q-card-section class="q-pt-lg q-px-lg q-pb-md">
+          <div class="text-h6 text-weight-bold text-grey-9">
+            {{ $t('uploadError.title') }}
+          </div>
+          <p class="text-body2 text-grey-8 q-mt-sm q-mb-none">
+            {{ $t('uploadError.lead') }}
+          </p>
+          <ul class="text-body2 text-grey-8 q-mt-sm q-mb-none q-pl-md">
+            <li>{{ $t('uploadError.bulletExtension') }}</li>
+            <li>{{ $t('uploadError.bulletRetry') }}</li>
+          </ul>
+        </q-card-section>
+        <q-card-actions
+          align="center"
+          class="q-pb-lg"
+        >
+          <q-btn
+            unelevated
+            no-caps
+            color="primary"
+            :label="$t('uploadError.ok')"
+            @click="uploadErrorDialogOpen = false"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </div>
+</template>
+
+<script>
+/* eslint-disable max-lines */
+import Parse from 'parse'
+
+import TakePhotoDialog from '~/components/dialogs/TakePhotoDialog.vue'
+import UploadPhotoDialog from '~/components/dialogs/UploadPhotoDialog.vue'
+import AssetModel from '~/models/Asset'
+import { assetFromModel } from '~/store/assets-manager/utils'
+import getCurrentUserId from '~/utils/getCurrentUserId'
+
+const PAGE_SIZE = 12
+const CHIP_COLORS = ['primary', 'deep-purple-6', 'teal-7', 'indigo-6', 'brown-7', 'orange-6', 'blue-5']
+const CATEGORY_CATALOG_KEY_PREFIX = 'mavoix.personalCategoryCatalog.'
+
+export default {
+  name: 'PageArasaacLibrary',
+  components: {
+    TakePhotoDialog,
+    UploadPhotoDialog
+  },
+  props: {
+    inDialog: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data () {
+    return {
+      takePhotoDialogOpen: false,
+      uploadPhotoDialogOpen: false,
+      pendingUploadFile: null,
+      personalPhotoSuccessOpen: false,
+      personalPhotoSuccessMode: 'take',
+      uploadErrorDialogOpen: false,
+      activeLibrary: 'arasaac',
+      search: '',
+      selectedCategoryFilters: [],
+      personalCategoryCatalog: [],
+      page: 1,
+      selectedUrls: [],
+      categoryMenuOpen: false,
+      categoryMenuTarget: null,
+      categoryMenuCategory: '',
+      imageCategoryDialogOpen: false,
+      imageCategoryTarget: null,
+      imageCategorySearch: '',
+      newCategoryNameForImage: '',
+      newCategoryName: '',
+      renameCategoryDialogOpen: false,
+      renameCategoryName: ''
+    }
+  },
+  computed: {
+    personalAssets () {
+      return this.$store.getters['assetsManager/all'] || []
+    },
+
+    // Bibliothèque personnelle: Parse.File uploads only (not ARASAAC/tab URL-only assets).
+    personalUploadAssets () {
+      return this.personalAssets.filter((a) => Boolean(a.file))
+    },
+    personalAssetByUrl () {
+      return this.personalAssets.reduce((acc, asset) => {
+        if (asset.url) acc[asset.url] = asset
+
+        return acc
+      }, {})
+    },
+    allImages () {
+      if (this.activeLibrary === 'personal') {
+        return this.personalUploadAssets.map((img) => ({
+          id: img.id,
+          url: img.url,
+          name: img.name || 'Picto Name',
+          categories: img.categories || []
+        }))
+      }
+
+      const source = this.$store.state.global.images || []
+
+      return source.map((img) => ({
+        id: img.url,
+        url: img.url,
+        name: (img.names && img.names.fr && img.names.fr[0]) || 'Picto Name',
+        categories: (this.personalAssetByUrl[img.url] && this.personalAssetByUrl[img.url].categories) || []
+      }))
+    },
+    categoryOptions () {
+      const fromAssets = this.allImages
+        .flatMap((img) => img.categories || [])
+        .filter(Boolean)
+
+      return Array.from(new Set([...this.personalCategoryCatalog, ...fromAssets]))
+    },
+    filteredCategoriesForImageDialog () {
+      const q = (this.imageCategorySearch || '').trim().toLowerCase()
+      const sorted = [...this.categoryOptions].sort((a, b) =>
+        a.localeCompare(b, 'fr', { sensitivity: 'base' })
+      )
+      if (!q) {
+        return sorted
+      }
+
+      return sorted.filter((c) => c.toLowerCase().includes(q))
+    },
+    filteredImages () {
+      const q = (this.search || '').trim().toLowerCase()
+
+      return this.allImages.filter((img) => {
+        const matchesText = !q || (img.name || '').toLowerCase().includes(q)
+        const matchesCategories = this.selectedCategoryFilters.length === 0 ||
+          this.selectedCategoryFilters.some((cat) => (img.categories || []).includes(cat))
+
+        return matchesText && matchesCategories
+      })
+    },
+    pageCount () {
+      return Math.max(1, Math.ceil(this.filteredImages.length / PAGE_SIZE))
+    },
+    paginatedImages () {
+      const start = (this.page - 1) * PAGE_SIZE
+
+      return this.filteredImages.slice(start, start + PAGE_SIZE)
+    },
+
+    tabItems () {
+      return this.$store.getters['tabEditor/items'] || []
+    },
+
+    personalPhotoSuccessTitle () {
+      return this.personalPhotoSuccessMode === 'upload'
+        ? this.$t('uploadPhoto.successTitle')
+        : this.$t('takePhoto.successTitle')
+    },
+
+    personalPhotoSuccessMessage () {
+      return this.personalPhotoSuccessMode === 'upload'
+        ? this.$t('uploadPhoto.successMessage')
+        : this.$t('takePhoto.successMessage')
+    },
+
+    personalPhotoSuccessOk () {
+      return this.personalPhotoSuccessMode === 'upload'
+        ? this.$t('uploadPhoto.successOk')
+        : this.$t('takePhoto.successOk')
+    },
+
+    pictogramCountLabel () {
+      const n = this.filteredImages.length
+
+      return n === 1
+        ? this.$t('addImagesModal.pictogramCountOne', { n })
+        : this.$t('addImagesModal.pictogramCountOther', { n })
+    }
+  },
+  watch: {
+    activeLibrary () {
+      this.page = 1
+      this.search = ''
+      this.selectedUrls = []
+      this.selectedCategoryFilters = []
+    },
+    search () {
+      this.page = 1
+    },
+    pageCount (count) {
+      if (this.page > count) this.page = count
+    }
+  },
+  mounted () {
+    this.loadCategoryCatalog()
+  },
+  methods: {
+    toggleLibrary () {
+      this.activeLibrary = this.activeLibrary === 'arasaac' ? 'personal' : 'arasaac'
+    },
+
+    getCategoryCatalogStorageKey () {
+      return `${CATEGORY_CATALOG_KEY_PREFIX}${getCurrentUserId()}`
+    },
+
+    loadCategoryCatalog () {
+      const raw = window.localStorage.getItem(this.getCategoryCatalogStorageKey())
+      this.personalCategoryCatalog = raw ? JSON.parse(raw) : []
+    },
+
+    saveCategoryCatalog () {
+      const deduped = Array.from(new Set(this.personalCategoryCatalog.filter(Boolean)))
+      this.personalCategoryCatalog = deduped
+      window.localStorage.setItem(this.getCategoryCatalogStorageKey(), JSON.stringify(deduped))
+    },
+
+    goBack () {
+      // This component is used inside a modal overlay from TabEditor.
+      this.$emit('close')
+    },
+
+    onTakePhotoSaved () {
+      this.personalPhotoSuccessMode = 'take'
+      this.$store.dispatch('assetsManager/loadAssets')
+      this.personalPhotoSuccessOpen = true
+    },
+
+    onUploadPhotoClick () {
+      this.$refs.uploadPhotoInput.click()
+    },
+
+    isValidUploadFile (file) {
+      const okMime = ['image/jpeg', 'image/jpg', 'image/png', 'image/pjpeg', 'image/x-png']
+      const okExt = /\.(jpe?g|png)$/i
+      if (file.type && okMime.includes(file.type)) {
+        return true
+      }
+      if (file.type && file.type.startsWith('image/') && okExt.test(file.name)) {
+        return true
+      }
+      if (!file.type && okExt.test(file.name)) {
+        return true
+      }
+
+      return okExt.test(file.name)
+    },
+
+    onUploadFileChosen (e) {
+      const input = e.target
+      const file = input.files && input.files[0]
+      input.value = ''
+      if (!file) {
+        return
+      }
+      if (!this.isValidUploadFile(file)) {
+        this.uploadErrorDialogOpen = true
+
+        return
+      }
+      this.pendingUploadFile = file
+      this.uploadPhotoDialogOpen = true
+    },
+
+    onUploadPhotoDialogInput (open) {
+      this.uploadPhotoDialogOpen = open
+      if (!open) {
+        this.pendingUploadFile = null
+      }
+    },
+
+    onUploadPhotoSaved () {
+      this.personalPhotoSuccessMode = 'upload'
+      this.$store.dispatch('assetsManager/loadAssets')
+      this.personalPhotoSuccessOpen = true
+    },
+
+    onUploadPhotoFailed () {
+      this.uploadErrorDialogOpen = true
+    },
+
+    onTakePhotoAddCategory (name) {
+      const n = (name || '').trim()
+      if (!n || this.personalCategoryCatalog.includes(n)) {
+        return
+      }
+      this.personalCategoryCatalog.push(n)
+      this.saveCategoryCatalog()
+    },
+
+    confirmAddCategory () {
+      const name = (this.newCategoryName || '').trim()
+      if (!name) {
+        return
+      }
+      if (!this.personalCategoryCatalog.includes(name)) {
+        this.personalCategoryCatalog.push(name)
+        this.saveCategoryCatalog()
+      }
+      this.newCategoryName = ''
+      this.$refs.addCategoryMenu?.hide()
+    },
+
+    openCategoryMenu (category, evt) {
+      this.categoryMenuCategory = category
+      this.categoryMenuTarget = evt.currentTarget
+      this.categoryMenuOpen = true
+    },
+
+    startRenameCategory () {
+      this.renameCategoryName = this.categoryMenuCategory
+      this.renameCategoryDialogOpen = true
+      this.categoryMenuOpen = false
+    },
+
+    async confirmRenameCategory () {
+      const from = this.categoryMenuCategory
+      const to = (this.renameCategoryName || '').trim()
+      if (!from || !to || from === to) {
+        this.renameCategoryDialogOpen = false
+
+        return
+      }
+
+      await this.updateCategoryForAllAssets(from, to)
+      const catIdx = this.personalCategoryCatalog.indexOf(from)
+      if (catIdx !== -1) {
+        this.personalCategoryCatalog.splice(catIdx, 1)
+        if (!this.personalCategoryCatalog.includes(to)) {
+          this.personalCategoryCatalog.push(to)
+        }
+        this.saveCategoryCatalog()
+      }
+      this.selectedCategoryFilters = Array.from(new Set(
+        this.selectedCategoryFilters.map((c) => (c === from ? to : c))
+      ))
+      this.renameCategoryDialogOpen = false
+      this.$store.dispatch('assetsManager/loadAssets')
+    },
+
+    async deleteCategoryFromAll () {
+      const category = this.categoryMenuCategory
+      if (!category) {
+        return
+      }
+      await this.updateCategoryForAllAssets(category, null)
+      this.selectedCategoryFilters = this.selectedCategoryFilters.filter((c) => c !== category)
+      this.personalCategoryCatalog = this.personalCategoryCatalog.filter((c) => c !== category)
+      this.saveCategoryCatalog()
+      this.categoryMenuOpen = false
+      this.$store.dispatch('assetsManager/loadAssets')
+    },
+
+    openImageCategoryDialog (image) {
+      this.imageCategoryTarget = image
+      this.imageCategorySearch = ''
+      this.newCategoryNameForImage = ''
+      this.imageCategoryDialogOpen = true
+    },
+
+    onImageCategoryDialogHide () {
+      this.imageCategoryTarget = null
+      this.imageCategorySearch = ''
+      this.newCategoryNameForImage = ''
+    },
+
+    async pickCategoryForImage (cat) {
+      await this.assignCategoryToImage(cat)
+    },
+
+    async submitNewCategoryFromImageDialog () {
+      const name = (this.newCategoryNameForImage || '').trim()
+      if (!name) {
+        return
+      }
+      await this.assignCategoryToImage(name)
+      this.newCategoryNameForImage = ''
+    },
+
+    async assignCategoryToImage (category) {
+      const name = (category || '').trim()
+      if (!name || !this.imageCategoryTarget) {
+        return
+      }
+      try {
+        await this.addCategoryToAsset(this.imageCategoryTarget, name)
+        if (!this.personalCategoryCatalog.includes(name)) {
+          this.personalCategoryCatalog.push(name)
+          this.saveCategoryCatalog()
+        }
+        this.imageCategoryDialogOpen = false
+        await this.$store.dispatch('assetsManager/loadAssets')
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e)
+        this.$q.notify({
+          position: 'top-right',
+          message: e.message || String(e),
+          color: 'negative'
+        })
+      }
+    },
+
+    async addCategoryToAsset (image, category) {
+      const userId = getCurrentUserId()
+      const existing = this.personalAssetByUrl[image.url]
+      let model
+      if (existing && existing.id) {
+        model = await new Parse.Query(AssetModel).get(existing.id)
+      } else {
+        model = await AssetModel.New(image.name || 'Picto Name', false, image.url, userId).save()
+      }
+      const categories = Array.from(new Set([...(model.get('categories') || []), category]))
+      model.set('categories', categories)
+      await model.save()
+    },
+
+    async updateCategoryForAllAssets (from, to) {
+      await Promise.all(this.personalAssets.map(async (asset) => {
+        const categories = asset.categories || []
+        if (!categories.includes(from)) {
+          return
+        }
+        const model = await new Parse.Query(AssetModel).get(asset.id)
+        const next = to
+          ? Array.from(new Set(categories.map((c) => (c === from ? to : c))))
+          : categories.filter((c) => c !== from)
+        model.set('categories', next)
+        await model.save()
+      }))
+    },
+
+    chipColor (category) {
+      let hash = 0
+      for (let i = 0; i < category.length; i += 1) {
+        hash = ((hash << 5) - hash) + category.charCodeAt(i)
+        hash |= 0
+      }
+
+      return CHIP_COLORS[Math.abs(hash) % CHIP_COLORS.length]
+    },
+
+    isHidden (url) {
+      const item = this.tabItems.find((it) => it.asset && it.asset.url === url)
+
+      return Boolean(item && item.hidden)
+    },
+
+    isUnavailable (url) {
+      const item = this.tabItems.find((it) => it.asset && it.asset.url === url)
+
+      return Boolean(item && !item.available)
+    },
+
+    async onAddSelected () {
+      try {
+        const uid = getCurrentUserId()
+
+        const uniqueUrls = Array.from(new Set(this.selectedUrls))
+        if (!uniqueUrls.length) {
+          this.$emit('close')
+
+          return
+        }
+
+        const assetsToAdd = await Promise.all(uniqueUrls.map(async (url) => {
+          const existing = this.tabItems.find((it) => it.asset && it.asset.url === url)
+          if (existing) {
+            return null
+          }
+
+          const entry = this.allImages.find((img) => img.url === url)
+          if (!entry || !entry.url) {
+            return null
+          }
+
+          const assetModel = await AssetModel.New(entry.name, false, entry.url, uid).save()
+          const assetObj = assetFromModel(assetModel)
+
+          return { assetObj, name: entry.name }
+        }))
+
+        assetsToAdd
+          .filter(Boolean)
+          .forEach(({ assetObj, name }) => {
+            this.$store.commit('tabEditor/setItemDialogName', name)
+            this.$store.commit('tabEditor/setItemDialogAsset', assetObj)
+            this.$store.commit('tabEditor/addItem')
+          })
+
+        await this.$store.dispatch('tabEditor/saveCb', () => { /* auto-save on add */ })
+
+        this.selectedUrls = []
+        this.$emit('close')
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e)
+        this.$q.notify({
+          position: 'top-right',
+          message: e.message || String(e),
+          color: 'red'
+        })
+      }
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+.arasaac-hidden-file-input
+  position absolute
+  width 0
+  height 0
+  opacity 0
+  pointer-events none
+
+.arasaac-page
+  background #f5f5f8
+  min-height 100%
+
+.arasaac-shell
+  margin 8px 10px 0
+  padding 12px 10px 8px
+  border-radius 6px
+
+.library-top-bar
+  flex-wrap wrap
+  row-gap 12px
+  column-gap 16px
+
+.library-top-actions
+  flex-wrap wrap
+  gap 8px 12px
+  margin-left auto
+  justify-content flex-end
+
+.arasaac-shell :deep(.q-field__native)
+  font-size 14px
+
+.arasaac-shell :deep(.q-btn)
+  font-size 13px
+  padding 4px 10px
+
+.arasaac-shell :deep(.library-footer-btn.q-btn)
+  padding 2px 12px
+  min-height 30px
+  border-radius 10px
+  box-shadow none !important
+
+.library-action
+  display flex
+  flex-direction column
+  align-items center
+  min-width 96px
+
+.library-action--clickable
+  cursor pointer
+  padding 8px 12px
+  border-radius 8px
+  transition background-color 0.15s ease
+  background-color transparent
+
+  &:hover
+    background-color rgba(0, 0, 0, 0.07)
+
+.library-action__label
+  font-size 11px
+  margin-top 4px
+  color #111827
+  text-align center
+
+.category-select
+  min-width 190px
+
+.library-grid
+  /* 6 cols on md+, 4 on sm, 3 on xs — 12 images = even rows */
+  align-items stretch
+
+.library-pagination
+  flex-shrink 0
+
+.library-card
+  background transparent
+  border-radius 8px
+
+.library-card__image
+  background #ffffff
+  border-radius 6px 6px 0 0
+  max-height 108px
+
+.library-card__actions
+  background transparent !important
+
+  pointer-events none
+  z-index 3
+
+.library-card__action-btn,
+.library-card__checkbox
+  pointer-events auto
+
+.image-overlay
+  display flex
+  align-items center
+  justify-content center
+  pointer-events none
+  z-index 2
+
+.image-overlay--hidden
+  background rgba(55, 68, 92, 0.78)
+
+.image-overlay--unavailable
+  background rgba(255, 255, 255, 0.55)
+
+.overlay-icon
+  font-size 96px
+  color #dfe5ee
+
+.overlay-icon--cross
+  color #e53935
+  font-weight 700
+
+.library-card__action-btn
+  background rgba(255, 255, 255, 0.75)
+
+.library-card__checkbox
+  background rgba(255, 255, 255, 0.75)
+  border-radius 4px
+  padding 0 2px
+
+.library-card__name
+  text-align center
+  padding 6px 6px
+  background #dfe5ef
+  color #374151
+  font-size 13px
+  line-height 1.3
+  border-radius 0 0 6px 6px
+
+.library-card__categories
+  display flex
+  align-items center
+  gap 4px
+  flex-wrap wrap
+  margin-top 6px
+  min-height 24px
+
+.category-chip
+  margin 0
+  font-size 12px
+  min-height 28px
+
+.image-category-chip
+  margin 0
+  font-size 11px
+  min-height 24px
+
+.add-category-menu__inner
+  min-width 280px
+</style>
+
+<style lang="stylus">
+/* Teleported popups/dialogs: classes must be unscoped */
+.category-filter-popup
+  min-width 280px
+
+.image-category-dialog-card
+  width 100%
+  max-width 360px
+  border-radius 10px
+
+.image-category-dialog__scroll
+  height 240px
+
+.image-category-dialog__chip
+  width 100%
+  justify-content flex-start
+  max-width 100%
+
+.take-photo-success-card
+  width 100%
+  max-width 400px
+  border-radius 12px
+  box-shadow 0 8px 32px rgba(0, 0, 0, 0.2)
+</style>

--- a/src/pages/TabEditor.vue
+++ b/src/pages/TabEditor.vue
@@ -99,7 +99,7 @@
                         <q-checkbox
                           dense
                           :value="!item.available"
-                          @input="() => $store.commit('tabEditor/toggleItemAvailable', item)"
+                          @input="() => onToggleAvailable(item)"
                         />
                       </q-item-section>
                       <q-item-section>
@@ -114,7 +114,7 @@
                         <q-checkbox
                           dense
                           :value="item.hidden"
-                          @input="() => $store.commit('tabEditor/toggleItemHidden', item)"
+                          @input="() => onToggleHidden(item)"
                         />
                       </q-item-section>
                       <q-item-section>
@@ -166,12 +166,21 @@
       </draggable>
     </div>
     <dialog-tab-item />
-    <dialog-item-choice ref="itemChoice" />
     <dialog-asset-delete
       :value="assetDeleteDialogOpen"
       @input="assetDeleteDialogOpen = $event"
       @confirm="onConfirmDeleteItem"
     />
+    <q-dialog
+      v-model="arasaacDialogOpen"
+    >
+      <q-card class="bg-white arasaac-modal-shell column no-wrap">
+        <arasaac-library
+          in-dialog
+          @close="arasaacDialogOpen = false"
+        />
+      </q-card>
+    </q-dialog>
 
     <q-page-sticky
       expand
@@ -181,9 +190,10 @@
         class="row items-center toolbar-no-border toolbar-with-padding"
         :style="{ background: tab.hexColor }"
       >
-        <!-- Add item button -->
+        <!-- Add item button — left edge aligns with .items-container (see .toolbar-with-padding) -->
         <q-btn
-          class="q-ml-md add-images-btn"
+          class="add-images-btn"
+          dense
           no-caps
           icon-right="add_to_photos"
           unelevated
@@ -212,64 +222,6 @@
       :tab="tab"
       @input="v => !v && closeTabSettings()"
     />
-
-    <!-- Delete, Save buttons -->
-    <q-page-sticky
-      position="bottom-right"
-      :offset="[18, 18]"
-    >
-      <q-btn
-        class="q-mx-xs"
-        fab
-        icon="delete"
-        color="negative"
-        @click="deletion = true"
-      >
-        <q-tooltip>
-          {{ $t('generic.delete') }}
-        </q-tooltip>
-      </q-btn>
-      <q-btn
-        class="q-mx-xs"
-        fab
-        icon="save"
-        size="xl"
-        color="primary"
-        @click="onSave"
-      >
-        <q-tooltip>
-          {{ $t('generic.save') }}
-        </q-tooltip>
-      </q-btn>
-    </q-page-sticky>
-    <q-dialog v-model="deletion">
-      <q-card>
-        <q-card-section>
-          <div class="text-h6">
-            Supprimer l'onglet
-          </div>
-        </q-card-section>
-
-        <q-card-section class="q-pt-none">
-          êtes-vous sûr de vouloir supprimer l'onglet ?
-        </q-card-section>
-
-        <q-card-actions align="right">
-          <q-btn
-            flat
-            label="Oui"
-            color="primary"
-            @click="onDelete"
-          />
-          <q-btn
-            flat
-            label="Non"
-            color="primary"
-            @click="deletion = false"
-          />
-        </q-card-actions>
-      </q-card>
-    </q-dialog>
 
     <q-dialog v-model="renameDialogOpen">
       <q-card style="min-width: 320px">
@@ -307,28 +259,25 @@
 
 <script>
 /* eslint-disable max-lines */
-import { SLUG_KEY } from '../models/Tab'
-
 import DialogAssetDelete from '~/components/dialogs/AssetDelete'
-import DialogItemChoice from '~/components/dialogs/ItemChoice'
 import DialogTabItem from '~/components/dialogs/TabItem'
 import DialogTabSettings from '~/components/dialogs/TabSettings'
-import { navigateAfterTabDeleted } from '~/utils/mavoixNavigation'
+import ArasaacLibrary from '~/pages/ArasaacLibrary'
 
 export default {
   name: 'PageTabEditor',
   components: {
     DialogTabItem,
-    DialogItemChoice,
     DialogTabSettings,
-    DialogAssetDelete
+    DialogAssetDelete,
+    ArasaacLibrary
   },
   data () {
     return {
+      arasaacDialogOpen: false,
       assetDeleteDialogOpen: false,
       assetDeleteTargetIndex: null,
       skipAssetDeleteConfirm: false,
-      deletion: false,
       tabSettingsDialogOpened: false,
       mode: 'create',
       inlineRenameIndex: null,
@@ -477,38 +426,6 @@ export default {
     },
 
     /**
-     * Call to save the tab
-     * @returns {void}
-     */
-    onSave () {
-      this.$store.dispatch('tabEditor/saveCb', (tab) => {
-        if (!tab) {
-          return
-        }
-
-        // When the tab's name is changed the slugs change to, so redirect to the new url
-        const path = `/tabs/${tab.get(SLUG_KEY)}`
-        if (this.$route.path !== path) this.$router.push(path)
-
-        // Toast message
-        this.$q.notify({
-          message: `${tab.get('name')} saved`,
-          color: 'purple'
-        })
-      })
-    },
-
-    /**
-     * Call to remove tab
-     * @returns {void}
-     */
-    async onDelete () {
-      await this.$store.dispatch('tabEditor/deleteTab')
-      this.deletion = false
-      navigateAfterTabDeleted(this.$router, this.$store)
-    },
-
-    /**
      * Set the tab's name
      * @param {string} name tab's name
      * @returns {void}
@@ -537,10 +454,7 @@ export default {
      * @returns {void}
      */
     onAddItem () {
-      this.$refs.itemChoice.opened = true
-      // this.$store.commit('tabEditor/openItemDialog', {})
-      // this.$store.commit('tabEditor/openItemChoice', {})
-      // this.$store.dispatch('global/initTTS')
+      this.arasaacDialogOpen = true
     },
 
     // eslint-disable-next-line valid-jsdoc
@@ -624,16 +538,28 @@ export default {
         return
       }
       this.$store.commit('tabEditor/removeItemAtIndex', index)
+      this.$store.dispatch('tabEditor/saveCb', () => { /* auto-save on delete */ })
     },
 
     saveDialogRename () {
       const nextName = (this.renameDialogDraft || '').trim()
       if (nextName && this.renameDialogTarget && this.renameDialogTarget.item) {
         this.renameDialogTarget.item.name = nextName
+        this.$store.dispatch('tabEditor/saveCb', () => { /* auto-save on rename */ })
       }
       this.renameDialogOpen = false
       this.renameDialogDraft = ''
       this.renameDialogTarget = null
+    },
+
+    onToggleAvailable (item) {
+      this.$store.commit('tabEditor/toggleItemAvailable', item)
+      this.$store.dispatch('tabEditor/saveCb', () => { /* auto-save on toggle available */ })
+    },
+
+    onToggleHidden (item) {
+      this.$store.commit('tabEditor/toggleItemHidden', item)
+      this.$store.dispatch('tabEditor/saveCb', () => { /* auto-save on toggle hidden */ })
     }
   }
 }
@@ -662,14 +588,16 @@ export default {
   border-bottom none !important
 
 .toolbar-with-padding
-  padding-top 12px
-  padding-bottom 12px
+  /* Same inset as first image: .items-container margin-left (4px) + q-gutter-x-md on row children (16px) */
+  padding 12px 12px 12px 65px
 
 .add-images-btn
   background white !important
   color black
-  border-radius 9999px
-  padding 8px 20px
+  border-radius 10px
+  padding 2px 12px
+  min-height 30px
+  box-shadow none !important
 
 .add-images-btn .q-icon
   color var(--q-color-primary)
@@ -731,7 +659,7 @@ export default {
   padding 0 10px
 
 .items-container
-  margin-top 24px
+  margin-top -10px
   margin-left 4px
 
 .holder-container
@@ -744,6 +672,22 @@ export default {
 
 .ghost
   opacity 0
+
+.arasaac-modal-shell
+  width calc(100vw - 90px)
+  max-width 1280px
+  height calc(100vh - 70px)
+  max-height 900px
+  border-radius 14px
+  overflow hidden
+  min-height 0
+
+.arasaac-modal-shell :deep(.arasaac-page)
+  flex 1 1 auto
+  min-height 0
+  overflow-y auto
+  overflow-x hidden
+  -webkit-overflow-scrolling touch
 
 /*
   div

--- a/src/store/assets-manager/actions.js
+++ b/src/store/assets-manager/actions.js
@@ -102,12 +102,11 @@ export const uploadFiles = async ({ commit }, { files, posNotif = 'top-right' })
 }
 
 /**
- * Upload a file and create the asset
- * @param {Context} ctx context passed vuex
- * @param {File} file the file to upload
+ * Resize image file to max 512px and return a Blob.
+ * @param {File} file source file
+ * @returns {Promise<Blob>} processed blob
  */
-
-const uploadFile = async ({ commit }, file) => {
+const prepareImageBlobFromFile = async (file) => {
   const image = await Jimp.read(await file.arrayBuffer())
   const maxDim = Math.max(image.bitmap.width, image.bitmap.height)
   if (maxDim > 512) {
@@ -118,7 +117,74 @@ const uploadFile = async ({ commit }, file) => {
     }
   }
   const buf = await image.getBufferAsync(Jimp.AUTO)
-  const blob = new Blob([buf])
+
+  return new Blob([buf])
+}
+
+/**
+ * Build upload blob + Parse filename; uses Jimp resize when possible, else original bytes (some JPEGs fail in Jimp).
+ * @param {File} file source file
+ * @param {string} baseFile safe base name without extension
+ * @returns {Promise<{ blob: Blob, filename: string }>} payload for Parse.File
+ */
+const blobForPersonalUpload = async (file, baseFile) => {
+  try {
+    const blob = await prepareImageBlobFromFile(file)
+
+    return { blob, filename: `${baseFile}.png` }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('Jimp could not process image, uploading original file:', err.message || err)
+    const buf = await file.arrayBuffer()
+    const extMatch = (file.name || '').match(/(\.jpe?g|\.png)$/i)
+    const ext = extMatch ? extMatch[1].toLowerCase() : '.jpg'
+    let mime = 'image/jpeg'
+    if (file.type && file.type.startsWith('image/')) {
+      mime = file.type
+    } else if (ext === '.png') {
+      mime = 'image/png'
+    }
+
+    return {
+      blob: new Blob([buf], { type: mime }),
+      filename: `${baseFile}${ext}`
+    }
+  }
+}
+
+/**
+ * Upload a camera-cropped photo with display name and optional categories (personal library only).
+ * @param {Object} ctx vuex context
+ * @param {Object} payload file and metadata
+ * @param {File} payload.file image file
+ * @param {string} payload.name display name
+ * @param {string[]} [payload.categories] category tags
+ * @returns {Promise<void>} resolves when the asset is saved
+ */
+export const uploadPersonalPhoto = async ({ commit }, { file, name, categories = [] }) => {
+  const displayName = (name || '').trim() || 'Photo'
+  const baseFile = Unidecode(displayName)
+    .replace(/^[^a-z0-9]+/i, '')
+    .replace(/[^a-z0-9. \-_]/gi, '_') || 'photo'
+  const { blob, filename } = await blobForPersonalUpload(file, baseFile)
+  const newFile = await new Parse.File(filename, blob).save()
+  const asset = await AssetModel.New(displayName, newFile, newFile._url, getCurrentUserId()).save()
+  const cats = Array.from(new Set((categories || []).filter(Boolean)))
+  if (cats.length) {
+    asset.set('categories', cats)
+    await asset.save()
+  }
+  commit('addAsset', asset)
+}
+
+/**
+ * Upload a file and create the asset
+ * @param {Context} ctx context passed vuex
+ * @param {File} file the file to upload
+ */
+
+const uploadFile = async ({ commit }, file) => {
+  const blob = await prepareImageBlobFromFile(file)
 
   const filename = Unidecode(file.name)
     .replace(/^[^a-z0-9]+/i, '')

--- a/src/store/assets-manager/utils.js
+++ b/src/store/assets-manager/utils.js
@@ -22,12 +22,14 @@ export const assetFromModel = (assetModel) => {
     ? parseFile.url()
     // ? `${Parse.serverURL}/files/${Parse.applicationId}/${parseFile._name}`
     : assetModel.get(URL_KEY)
+  const categories = assetModel.get('categories') || []
 
   return {
     id: assetModel.id,
     name: assetModel.get(NAME_KEY),
     url: url,
-    file: parseFile
+    file: parseFile,
+    categories
   }
 }
 

--- a/src/store/tab-editor/actions.js
+++ b/src/store/tab-editor/actions.js
@@ -64,7 +64,7 @@ export const fetchItems = ({ commit, getters: { tab } }) => {
  * @param {Function} callback to call when tab saved
  * @returns {Promise} saveCb succeeded
  */
-export const saveCb = async ({ commit, dispatch, getters: { tab, items, deletedItems } }, callback) => {
+export const saveCb = async ({ commit, getters: { tab, items, deletedItems } }, callback) => {
   try {
     const tabModel = await tabToModel(tab)
     const promises = []
@@ -113,12 +113,9 @@ export const saveCb = async ({ commit, dispatch, getters: { tab, items, deletedI
 
       return itemModel.save()
     }))
-    commit('clearState')
+    commit('clearDeletedItems')
 
-    return Promise.all([
-      dispatch('loadBySlug', tabModel.get(SLUG_KEY)),
-      callback(tabModel)
-    ])
+    return callback(tabModel)
   } catch (err) {
     commit('setError', err)
 

--- a/src/store/tab-editor/mutations.js
+++ b/src/store/tab-editor/mutations.js
@@ -175,22 +175,9 @@ export const openItemDialog = (state, { mode = 'new', index, data }) => {
   }
 }
 
-// export const openItemChoice = (state, { mode = 'new', index, data }) => {
-//   state.itemChoice.opened = true
-//   state.itemChoice.mode = mode
-//   if (mode === 'edit') {
-//     state.itemChoice.data = data
-//     state.itemChoice.index = index
-//   }
-// }
-
 export const openLanguageChoice = (state) => {
   state.itemLanguage.opened = true
 }
-
-// export const closeItemChoice = (state, { mode = 'new', index, data }) => {
-//   state.itemChoice.opened = false
-// }
 
 /**
  * Remove the item loaded in the dialog for the list of items
@@ -282,6 +269,15 @@ export const redo = (state) => {
  */
 export const clearState = (state) => {
   Object.assign(state, getDefaultState())
+}
+
+/**
+ * Clear only the deleted items queue after a successful save
+ * @param {State} state vuex state
+ * @return {void}
+ */
+export const clearDeletedItems = (state) => {
+  state.deletedItems = []
 }
 
 /**


### PR DESCRIPTION
### Summary
Revamp of the Add images experience on the tab editor: users can browse ARASAAC or a personal library, search, filter by category, take a photo, upload a photo, and add pictos to the tab—with layout and styling brought in line with [Figma.](https://www.figma.com/design/d8UDQ3EKuEPcWgqjSx32Xn/MaVoix_Panel-_Final?node-id=1-29083&t=n201E7fUngh4CgMY-0)

### Features & behaviour

- Two libraries — Switch between ARASAAC and bibliothèque personnelle (personal uploads / catalog).
- Take a photo — Opens the camera flow and saves into the personal workflow as designed.
- Upload a photo — File picker for images (e.g. jpg/png) into the same personal-library path.
- Search — Separate placeholders / behaviour for ARASAAC vs personal picto search where applicable.
- Filters — Category filter (multi-select / chips) to narrow the grid; category management (add, assign, rename, delete) as implemented in the modal.
- Grid & selection — Picto grid with selection, pagination, and actions consistent with the new modal shell.

Add Images Modal :
<img width="1278" height="791" alt="image" src="https://github.com/user-attachments/assets/4ad240cc-8aa6-41e4-9498-4d1f3ba70a9b" />

Categories/Tags :
<img width="1294" height="785" alt="image" src="https://github.com/user-attachments/assets/cfa266b0-a261-4736-867d-0405329b88c2" />

Personal Library :
<img width="1278" height="790" alt="image" src="https://github.com/user-attachments/assets/0732e999-5b19-4937-8ee7-cc5a785a754a" />

Take/Upload Photo :
<img width="1280" height="789" alt="image" src="https://github.com/user-attachments/assets/183e1cbd-f070-4005-8176-0b0cc11d45e1" />
